### PR TITLE
Añadidas referencias a las librerías

### DIFF
--- a/nodes/GlaDOSFirmware/platformio.ini
+++ b/nodes/GlaDOSFirmware/platformio.ini
@@ -35,7 +35,16 @@ env_default = d1_mini
 
 [env:d1_mini]
 platform = espressif8266
-lib_extra_dirs = ~/Documents/Arduino/libraries
+#lib_extra_dirs = ~/Documents/Arduino/libraries
+lib_deps =
+   WiFiManager@0.12
+   ArduinoJson@5.13.1
+   Adafruit NeoPixel@1.1.6
+   PubSubClient@2.6
+   Adafruit Unified Sensor@1.0.2
+   DHT sensor library@1.3.0
+   MFRC522@1.3.6
+
 board = d1_mini
 framework = arduino
 

--- a/nodes/GlaDOSFirmware/platformio.ini
+++ b/nodes/GlaDOSFirmware/platformio.ini
@@ -44,6 +44,7 @@ lib_deps =
    Adafruit Unified Sensor@1.0.2
    DHT sensor library@1.3.0
    MFRC522@1.3.6
+   EasyNTPClient@1.1.0
 
 board = d1_mini
 framework = arduino

--- a/nodes/GlaDOSFirmware/src/doorControlNode.h
+++ b/nodes/GlaDOSFirmware/src/doorControlNode.h
@@ -5,7 +5,9 @@
 #include "nfcModule.h"
 #include "relay.h"
 
+#ifdef HARDCODED_CARDS
 #include "cards.h"
+#endif
 
 class doorControlNode : public gladosMQTTNode
 {


### PR DESCRIPTION
Se han añadido las referencias a las librarías necesarias en la configuración de platformio.  Ahora es suficiente con hacer un build y platformio buscará las librerías necesarias y las instalará en el proyecto.